### PR TITLE
Simplify run_printer

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use cairo_lang_parser::utils::{get_syntax_root_and_diagnostics_from_file, SimpleParserDatabase};
 use hanji::utils::get_cairo_files_in_path;
-use hanji::{run_printer, MarkdownEngine};
+use hanji::{print_markdown, run_printer, MarkdownEngine};
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -34,7 +34,7 @@ fn main() {
 
             let mut file = File::create(&doc_file_path.into_os_string().to_str().unwrap()).unwrap();
 
-            let docs = generate_cairo_file_docs(cairo_file.to_str().unwrap());
+            let docs = print_markdown(cairo_file.to_str().unwrap());
             file.write_all(docs.as_bytes()).unwrap();
         }
     } else {
@@ -45,10 +45,6 @@ fn main() {
     // cairo_lang_syntax_codegen::cairo_spec::get_spec
 }
 
-fn generate_cairo_file_docs(cairo_filename: &str) -> String {
-    run_printer(cairo_filename, MarkdownEngine::new())
-}
-
 fn print_cairo_file_docs(cairo_filename: &str) {
-    println!("{}", generate_cairo_file_docs(cairo_filename));
+    println!("{}", print_markdown(cairo_filename));
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -46,12 +46,7 @@ fn main() {
 }
 
 fn generate_cairo_file_docs(cairo_filename: &str) -> String {
-    let db_val = SimpleParserDatabase::default();
-    let db = &db_val;
-
-    let (syntax_root, _diagnostics) = get_syntax_root_and_diagnostics_from_file(db, cairo_filename);
-
-    run_printer(db, &syntax_root, MarkdownEngine::new())
+    run_printer(cairo_filename, MarkdownEngine::new())
 }
 
 fn print_cairo_file_docs(cairo_filename: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod template_engine;
 pub mod utils;
 pub use printer::run_printer;
 pub use template_engine::{MarkdownEngine, TemplateEngine};
+pub use utils::print_markdown;

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,3 +1,4 @@
+use cairo_lang_parser::utils::{get_syntax_root_and_diagnostics_from_file, SimpleParserDatabase};
 // Source cairo/crates/cairo-lang-parser/src/printer.rs
 use cairo_lang_syntax as syntax;
 use cairo_lang_syntax::node::db::SyntaxGroup;
@@ -8,18 +9,27 @@ use cairo_lang_syntax_codegen::spec::{Member, Node, NodeKind};
 use colored::{ColoredString, Colorize};
 use itertools::zip_eq;
 use smol_str::SmolStr;
+use std::panic;
 
 use crate::template_engine::TemplateEngine;
 
-pub fn run_printer(
-    db: &dyn SyntaxGroup,
-    syntax_root: &SyntaxNode,
-    mut template_engine: impl TemplateEngine,
-) -> String {
-    template_engine.init(db);
-    let mut printer = Printer::new(db, template_engine);
-    printer.print_tree("root", syntax_root, "", true, true);
-    printer.template_engine.get_result()
+pub fn run_printer(cairo_filename: &str, mut template_engine: impl TemplateEngine) -> String {
+    let db_val = SimpleParserDatabase::default();
+    let db = &db_val;
+    let mut print = String::new();
+
+    let result = panic::catch_unwind(|| {
+        let (_, _) = get_syntax_root_and_diagnostics_from_file(db, cairo_filename);
+    });
+    if result.is_ok() {
+        let (syntax_root, _diagnostics) =
+            get_syntax_root_and_diagnostics_from_file(db, cairo_filename);
+        template_engine.init(db);
+        let mut printer = Printer::new(db, template_engine);
+        printer.print_tree("root", &syntax_root, "", true, true);
+        print.push_str(&printer.template_engine.get_result());
+    }
+    print
 }
 
 pub struct Printer<'a, T: TemplateEngine> {
@@ -250,22 +260,46 @@ impl<'a, T: TemplateEngine> Printer<'a, T> {
 
     // Color helpers.
     fn bold(&self, text: ColoredString) -> ColoredString {
-        if self.print_colors { text.bold() } else { text }
+        if self.print_colors {
+            text.bold()
+        } else {
+            text
+        }
     }
     fn green(&self, text: ColoredString) -> ColoredString {
-        if self.print_colors { text.green() } else { text }
+        if self.print_colors {
+            text.green()
+        } else {
+            text
+        }
     }
     fn red(&self, text: ColoredString) -> ColoredString {
-        if self.print_colors { text.red() } else { text }
+        if self.print_colors {
+            text.red()
+        } else {
+            text
+        }
     }
     fn cyan(&self, text: ColoredString) -> ColoredString {
-        if self.print_colors { text.cyan() } else { text }
+        if self.print_colors {
+            text.cyan()
+        } else {
+            text
+        }
     }
     fn blue(&self, text: ColoredString) -> ColoredString {
-        if self.print_colors { text.blue() } else { text }
+        if self.print_colors {
+            text.blue()
+        } else {
+            text
+        }
     }
     fn bright_purple(&self, text: ColoredString) -> ColoredString {
-        if self.print_colors { text.bright_purple() } else { text }
+        if self.print_colors {
+            text.bright_purple()
+        } else {
+            text
+        }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+use crate::{run_printer, MarkdownEngine};
+
+/// Parses dir for Cairo files
 pub fn get_cairo_files_in_path(dir: &PathBuf) -> Vec<PathBuf> {
     let mut cairo_files: Vec<PathBuf> = vec![];
     let dir_iter = dir.read_dir().unwrap();
@@ -15,4 +18,9 @@ pub fn get_cairo_files_in_path(dir: &PathBuf) -> Vec<PathBuf> {
         }
     }
     cairo_files
+}
+
+/// Returns markdown for a file
+pub fn print_markdown(cairo_filename: &str) -> String {
+    run_printer(cairo_filename, MarkdownEngine::new())
 }


### PR DESCRIPTION
* Simplifies `run_printer` function to run the printer for provided `.cairo` file.
* Public `print_markdown` function to print markdown docs for a `.cairo` file.