### PR TITLE
Types for Template engine

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,11 +1,9 @@
+use hanji::print_markdown;
+use hanji::utils::get_cairo_files_in_path;
 use std::env;
 use std::fs::{create_dir, create_dir_all, remove_dir_all, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
-
-use cairo_lang_parser::utils::{get_syntax_root_and_diagnostics_from_file, SimpleParserDatabase};
-use hanji::utils::get_cairo_files_in_path;
-use hanji::{print_markdown, run_printer, MarkdownEngine};
 fn main() {
     let args: Vec<String> = env::args().collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 pub mod printer;
 pub mod template_engine;
 pub mod utils;
+// For using cairo lang types
+pub use cairo_lang_syntax::node::db::SyntaxGroup;
+pub use cairo_lang_syntax::node::kind::SyntaxKind;
+pub use cairo_lang_syntax::node::SyntaxNode;
+// Hanji types/functions
 pub use printer::run_printer;
 pub use template_engine::{MarkdownEngine, TemplateEngine};
 pub use utils::print_markdown;

--- a/src/template_engine/markdown.rs
+++ b/src/template_engine/markdown.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::kind::SyntaxKind::*;
-use cairo_lang_syntax::node::SyntaxNode;
+use crate::SyntaxGroup;
+use crate::SyntaxKind;
+use crate::SyntaxKind::*;
+use crate::SyntaxNode;
 
 use super::TemplateEngine;
 


### PR DESCRIPTION
Export all types required to build a template engine, so that no other crates are required.